### PR TITLE
Reinforce from inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Desktop.ini
 .tox
 .cache
 .vscode/settings.json
+venv

--- a/src/libs/CrabadaWeb2Client/CrabadaWeb2Client.py
+++ b/src/libs/CrabadaWeb2Client/CrabadaWeb2Client.py
@@ -178,3 +178,34 @@ class CrabadaWeb2Client:
         }
         actualParams = defaultParams | params
         return requests.request("GET", url, params=actualParams).json()  # type: ignore
+
+    def listCrabsForLendingFromInventory(
+        self, user_address: Address, params: dict[str, Any] = {}
+    ) -> List[CrabForLending]:
+        """
+        Get all crabs available for lending as reinforcements from users own inventory.
+        """
+        params["user_address"] = user_address
+        res = self.listCrabsForLendingFromInventory_Raw(params)
+        try:
+            crabadas = res["result"]["data"] or []
+            for cra in crabadas:
+                # lending(tavern) and can-join-team(inventory) api has different fields for crabs.
+                # add missing information for this endpoint.
+
+                # price is important, it is required by the contract
+                # and we may use it for ordering and stuff...
+                cra["price"] = 0
+
+                # others not so much...
+                cra["lender"] = ""
+                cra["is_being_borrowed"] = 0
+                cra["borrower"] = ""
+                cra["game_id"] = 0
+            return crabadas
+        except:
+            return []
+
+    def listCrabsForLendingFromInventory_Raw(self, params: dict[str, Any] = {}) -> Any:
+        url = self.baseUri + "/crabadas/can-join-team"
+        return requests.request("GET", url, params=params).json()  # type: ignore

--- a/src/strategies/reinforce/InventoryOrHighestBP.py
+++ b/src/strategies/reinforce/InventoryOrHighestBP.py
@@ -1,0 +1,50 @@
+from typing import Any, List
+from src.libs.CrabadaWeb2Client.types import CrabForLending, Game
+from src.strategies.reinforce.ReinforceStrategy import ReinforceStrategy
+from src.helpers.general import nthOrLastOrNone
+from src.helpers.price import weiToTus
+
+
+class InventoryOrHighestBP(ReinforceStrategy):
+    """
+    Strategy that chooses the crab with a price lower than maxPrice
+    which has the highest mine point value
+    """
+
+    def query(self, game: Game) -> dict[str, Any]:
+        """ """
+        return None
+
+    def getFromInventoryOrTavern(self, game: Game) -> List[CrabForLending]:
+        """
+        1. Checks inventory first for self/reinforceable crabs.
+        2. If no crab is available, uses tavern as usual.
+        """
+        inventory_crabs = self.web2Client.listCrabsForLendingFromInventory(
+            user_address=self.user.address
+        )
+        if inventory_crabs:
+            return inventory_crabs
+
+        params = {
+            "limit": 200,  # TODO: make it an argument
+            "orderBy": "price",
+            "order": "asc",
+        }
+        return self.web2Client.listCrabsForLending(params)
+
+    def process(self, game: Game, crabs: List[CrabForLending]) -> List[CrabForLending]:
+
+        # query() returns None, so crabs list given here should be empty as well.
+        # we can replace it with our custom ultimate-crab-getting-logic
+        crabs = self.getFromInventoryOrTavern(game=game)
+
+        affordableCrabs = [c for c in crabs if weiToTus(c["price"]) < self.maxPrice1]
+        return sorted(affordableCrabs, key=lambda c: (-c["battle_point"], c["price"]))
+
+    def pick(self, game: Game, crabs: List[CrabForLending]) -> CrabForLending:
+        """
+        Pick the n-th crab or, if there are fewer than n, the last one
+        """
+        n = self.teamConfig["reinforcementToPick"]
+        return nthOrLastOrNone(crabs, n - 1)

--- a/src/strategies/reinforce/InventoryOrHighestBP.py
+++ b/src/strategies/reinforce/InventoryOrHighestBP.py
@@ -41,10 +41,3 @@ class InventoryOrHighestBP(ReinforceStrategy):
 
         affordableCrabs = [c for c in crabs if weiToTus(c["price"]) < self.maxPrice1]
         return sorted(affordableCrabs, key=lambda c: (-c["battle_point"], c["price"]))
-
-    def pick(self, game: Game, crabs: List[CrabForLending]) -> CrabForLending:
-        """
-        Pick the n-th crab or, if there are fewer than n, the last one
-        """
-        n = self.teamConfig["reinforcementToPick"]
-        return nthOrLastOrNone(crabs, n - 1)

--- a/src/strategies/reinforce/InventoryOrHighestBP.py
+++ b/src/strategies/reinforce/InventoryOrHighestBP.py
@@ -7,8 +7,8 @@ from src.helpers.price import weiToTus
 
 class InventoryOrHighestBP(ReinforceStrategy):
     """
-    Strategy that chooses the crab with a price lower than maxPrice
-    which has the highest mine point value
+    If Inventory Crab is available, then reinforce with it
+    Else, reinforce using tavern with maxTus price set and strategy.
     """
 
     def query(self, game: Game) -> dict[str, Any]:

--- a/src/strategies/reinforce/InventoryOrHighestMP.py
+++ b/src/strategies/reinforce/InventoryOrHighestMP.py
@@ -7,8 +7,8 @@ from src.helpers.price import weiToTus
 
 class InventoryOrHighestMP(ReinforceStrategy):
     """
-    Strategy that chooses the crab with a price lower than maxPrice
-    which has the highest mine point value
+    If Inventory Crab is available, then reinforce with it
+    Else, reinforce using tavern with maxTus price set and strategy.
     """
 
     def query(self, game: Game) -> dict[str, Any]:

--- a/src/strategies/reinforce/InventoryOrHighestMP.py
+++ b/src/strategies/reinforce/InventoryOrHighestMP.py
@@ -41,10 +41,3 @@ class InventoryOrHighestMP(ReinforceStrategy):
 
         affordableCrabs = [c for c in crabs if weiToTus(c["price"]) < self.maxPrice1]
         return sorted(affordableCrabs, key=lambda c: (-c["mine_point"], c["price"]))
-
-    def pick(self, game: Game, crabs: List[CrabForLending]) -> CrabForLending:
-        """
-        Pick the n-th crab or, if there are fewer than n, the last one
-        """
-        n = self.teamConfig["reinforcementToPick"]
-        return nthOrLastOrNone(crabs, n - 1)

--- a/src/strategies/reinforce/InventoryOrHighestMP.py
+++ b/src/strategies/reinforce/InventoryOrHighestMP.py
@@ -1,0 +1,50 @@
+from typing import Any, List
+from src.libs.CrabadaWeb2Client.types import CrabForLending, Game
+from src.strategies.reinforce.ReinforceStrategy import ReinforceStrategy
+from src.helpers.general import nthOrLastOrNone
+from src.helpers.price import weiToTus
+
+
+class InventoryOrHighestMP(ReinforceStrategy):
+    """
+    Strategy that chooses the crab with a price lower than maxPrice
+    which has the highest mine point value
+    """
+
+    def query(self, game: Game) -> dict[str, Any]:
+        """ """
+        return None
+
+    def getFromInventoryOrTavern(self, game: Game) -> List[CrabForLending]:
+        """
+        1. Checks inventory first for self/reinforceable crabs.
+        2. If no crab is available, uses tavern as usual.
+        """
+        inventory_crabs = self.web2Client.listCrabsForLendingFromInventory(
+            user_address=self.user.address
+        )
+        if inventory_crabs:
+            return inventory_crabs
+
+        params = {
+            "limit": 200,  # TODO: make it an argument
+            "orderBy": "price",
+            "order": "asc",
+        }
+        return self.web2Client.listCrabsForLending(params)
+
+    def process(self, game: Game, crabs: List[CrabForLending]) -> List[CrabForLending]:
+
+        # query() returns None, so crabs list given here should be empty as well.
+        # we can replace it with our custom ultimate-crab-getting-logic
+        crabs = self.getFromInventoryOrTavern(game=game)
+
+        affordableCrabs = [c for c in crabs if weiToTus(c["price"]) < self.maxPrice1]
+        return sorted(affordableCrabs, key=lambda c: (-c["mine_point"], c["price"]))
+
+    def pick(self, game: Game, crabs: List[CrabForLending]) -> CrabForLending:
+        """
+        Pick the n-th crab or, if there are fewer than n, the last one
+        """
+        n = self.teamConfig["reinforcementToPick"]
+        return nthOrLastOrNone(crabs, n - 1)

--- a/src/strategies/reinforce/ReinforceStrategyFactory.py
+++ b/src/strategies/reinforce/ReinforceStrategyFactory.py
@@ -20,6 +20,8 @@ from src.strategies.reinforce.CheapestCrabReinforceStrategy import (
     CheapestCrabReinforceStrategy,
 )
 from src.strategies.reinforce.NoReinforceStrategy import NoReinforceStrategy
+from src.strategies.reinforce.InventoryOrHighestBP import InventoryOrHighestBP
+from src.strategies.reinforce.InventoryOrHighestMP import InventoryOrHighestMP
 from src.strategies.reinforce.ReinforceStrategy import ReinforceStrategy
 from src.models.User import User
 
@@ -28,6 +30,8 @@ reinforceStrategies = {
     "CheapestCrab": CheapestCrabReinforceStrategy,
     "HighestBp": HighestBpReinforceStrategy,
     "HighestMp": HighestMpReinforceStrategy,
+    "InventoryOrHighestBP": InventoryOrHighestBP,
+    "InventoryOrHighestMP": InventoryOrHighestMP,
 }
 
 


### PR DESCRIPTION
resolves #13

Adds two new strategy: InventoryOrHighestMP, InventoryOrHighestBP.

* **Readme Suggestion:** Crabs can be in a Team, Marketplace Inventory, Game Inventory or Tavern. It is a bit confusing at first. If a crab is inventory-hireable, it should be seen in [this end point](https://idle-api.crabada.com/public/idle/crabadas/can-join-team?user_address=0xyour-public-address-here)