### PR TITLE
Updated Manual Looting Implementation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,10 @@ USER_1_REINFORCEMENT_MAX_PRICE="25" # in TUS - will not reinforce if borrow pric
 USER_1_REINFORCEMENT_MAX_GAS="inf" # in gwei - will not reinforce if base fee is larger than this (set to "inf" or delete line for no limit)
 USER_1_MINE_MAX_GAS="inf" # in gwei - will not start mine if base fee is larger than this (set to "inf" or delete line for no limit)
 USER_1_CLOSE_MINE_MAX_GAS="inf" # in gwei - will not close mine if base fee is larger than this (set to "inf" or delete line for no limit)
+# Override for setting all teams to mine
+USER_1_ALL_MINE_TIME_START_HOUR="23" # time to set all the teams to mining and diregard the below tasks
+USER_1_ALL_MINE_TIME_STOP_HOUR="08" # time to stop setting all the teams to mining and use the below
+
 # =========
 # = TEAMS =
 # =========

--- a/.env.example
+++ b/.env.example
@@ -36,9 +36,10 @@ USER_1_REINFORCEMENT_MAX_PRICE="25" # in TUS - will not reinforce if borrow pric
 USER_1_REINFORCEMENT_MAX_GAS="inf" # in gwei - will not reinforce if base fee is larger than this (set to "inf" or delete line for no limit)
 USER_1_MINE_MAX_GAS="inf" # in gwei - will not start mine if base fee is larger than this (set to "inf" or delete line for no limit)
 USER_1_CLOSE_MINE_MAX_GAS="inf" # in gwei - will not close mine if base fee is larger than this (set to "inf" or delete line for no limit)
-# Override for setting all teams to mine
-USER_1_ALL_MINE_TIME_START_HOUR="23" # time to set all the teams to mining and diregard the below tasks
-USER_1_ALL_MINE_TIME_STOP_HOUR="08" # time to stop setting all the teams to mining and use the below
+
+# Override for setting all teams to mine in a paricular time period (typically overnight) - works on local time
+USER_1_ALL_MINE_TIME_START_HOUR="23" # time to set all the teams to mining and disegard the below tasks
+USER_1_ALL_MINE_TIME_STOP_HOUR="08" # time to stop setting all the teams to mining and use the below tasks
 
 # =========
 # = TEAMS =

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Reinforce-specific features:
 
 - Run `python -m bin.looting.reinforceAttack <your address>` to reinforce all attacking teams with a crab from the tavern, using the reinforcement strategy specified in the .env file.
 - Run `python -m bin.looting.closeLoots <your address>` to settle and claim rewards on loots that can be settled.
+- Run `python -m bin.looting.notifyTeamsIdle <your address>` to notify when the looting teams are sitting idle and they are waiting to be manually sent to loot
 
 ### - What about attacking? 🤔
 

--- a/bin/looting/notifyTeamsIdle.py
+++ b/bin/looting/notifyTeamsIdle.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""
+Crabada script to notify user of idle looting teams
+for the given user address.
+
+Usage:
+    python3 -m bin.looting.notifyTeamsIdle <userAddress>
+
+Author:
+    @coccoinomane (Twitter)
+"""
+
+from src.bot.looting.notifyTeamsIdle import notifyTeamsIdle
+from src.helpers.general import secondOrNone
+from src.models.User import User
+from src.common.logger import logger
+from sys import argv
+
+userAddress = secondOrNone(argv)
+
+if not userAddress:
+    logger.error("Specify a user address")
+    exit(1)
+
+nClosed = notifyTeamsIdle(User(userAddress))

--- a/src/bot/looting/notifyTeamsIdle.py
+++ b/src/bot/looting/notifyTeamsIdle.py
@@ -1,0 +1,39 @@
+"""
+Send a user's available teams mining
+"""
+
+from src.common.logger import logger
+from src.common.txLogger import txLogger, logTx
+from src.helpers.instantMessage import sendIM
+from src.common.clients import makeCrabadaWeb3Client
+from src.helpers.teams import fetchAvailableTeamsForTask
+from src.models.User import User
+from web3.exceptions import ContractLogicError
+
+
+def notifyTeamsIdle(user: User) -> int:
+    """
+    Send mining the available teams with the 'mine' task
+    Notify the idle teams to the user
+
+    Returns the opened mines
+    """
+    client = makeCrabadaWeb3Client(
+        upperLimitForBaseFeeInGwei=user.config["mineMaxGasInGwei"]
+    )
+    availableTeams = fetchAvailableTeamsForTask(user, "loot")
+
+    if not availableTeams:
+        logger.info("No available teams to send looting for user " + str(user.address))
+        return 0
+
+    # Send the teams
+    nIdleTeams = 0
+    for t in availableTeams:
+
+        # Send team
+        teamId = t["team_id"]
+        logger.info(f"Team {teamId} is sitting idle! Go start the loot... 🦀")
+        sendIM(f"Team {teamId} is sitting idle! Go start the loot... 🦀", forceSend=True, disableNotifications=False);
+
+    return nIdleTeams

--- a/src/bot/looting/notifyTeamsIdle.py
+++ b/src/bot/looting/notifyTeamsIdle.py
@@ -1,5 +1,5 @@
 """
-Send a user's available teams mining
+Notify a user where they have available looting teams sitting idle
 """
 
 from src.common.logger import logger
@@ -13,10 +13,10 @@ from web3.exceptions import ContractLogicError
 
 def notifyTeamsIdle(user: User) -> int:
     """
-    Send mining the available teams with the 'mine' task
+    Send a notification to the user when they have available teams with the 'loot' task sitting idle
     Notify the idle teams to the user
 
-    Returns the opened mines
+    Returns the number of idle teams
     """
     client = makeCrabadaWeb3Client(
         upperLimitForBaseFeeInGwei=user.config["mineMaxGasInGwei"]
@@ -27,11 +27,11 @@ def notifyTeamsIdle(user: User) -> int:
         logger.info("No available teams to send looting for user " + str(user.address))
         return 0
 
-    # Send the teams
+    # Loop through available looting teams
     nIdleTeams = 0
     for t in availableTeams:
 
-        # Send team
+        # Send a notification of the idle team
         teamId = t["team_id"]
         logger.info(f"Team {teamId} is sitting idle! Go start the loot... 🦀")
         sendIM(f"Team {teamId} is sitting idle! Go start the loot... 🦀", forceSend=True, disableNotifications=False);

--- a/src/helpers/config.py
+++ b/src/helpers/config.py
@@ -76,8 +76,8 @@ def parseUserConfig(userNumber: int, teams: List[ConfigTeam]) -> ConfigUser:
         "closeMineMaxGasInGwei": parseFloat(
             f"{userPrefix}_CLOSE_MINE_MAX_GAS", float("inf")
         ),
-        "allMineTimeStart": getenv(f"{userPrefix}_ALL_MINE_TIME_START_HOUR"),
-        "allMineTimeEnd": getenv(f"{userPrefix}_ALL_MINE_TIME_STOP_HOUR"),
+        "allMineTimeStart": parseInt(f"{userPrefix}_ALL_MINE_TIME_START_HOUR"),
+        "allMineTimeEnd": parseInt(f"{userPrefix}_ALL_MINE_TIME_STOP_HOUR"),
         "teams": [t for t in teams if t["userAddress"] == address],
     }
 

--- a/src/helpers/dates.py
+++ b/src/helpers/dates.py
@@ -5,3 +5,12 @@ def getPrettySeconds(s: int) -> str:
     m, s = divmod(s, 60)
     h, m = divmod(m, 60)
     return f"{h:d}h:{m:02d}m:{s:02d}s"
+
+def isNowInTimePeriod(startTime, endTime, nowTime): 
+    """Compares three times to see if the now Time is inside the period
+    https://stackoverflow.com/questions/10048249/how-do-i-determine-if-current-time-is-within-a-specified-range-using-pythons-da"""
+    if startTime < endTime: 
+        return nowTime >= startTime and nowTime <= endTime 
+    else: 
+        #Over midnight:
+        return nowTime >= startTime or nowTime <= endTime 

--- a/src/helpers/instantMessage.py
+++ b/src/helpers/instantMessage.py
@@ -5,7 +5,7 @@ import requests
 import json
 
 
-def sendIM(body: str, forceSend: bool = False) -> bool:
+def sendIM(body: str, forceSend: bool = False, disableNotifications: bool = True) -> bool:
     """Send an notification message to the service configured in .env; won't send
     anything if notifications are disabled, unless forceSend is True"""
 
@@ -16,7 +16,7 @@ def sendIM(body: str, forceSend: bool = False) -> bool:
     try:
         if telegram["enable"]:
             notification_result = sendTelegramMessage(
-                body=body, apiKey=telegram["apiKey"], chatId=telegram["chatId"]
+                body=body, apiKey=telegram["apiKey"], chatId=telegram["chatId"], disableNotifications=disableNotifications
             )
 
         # NOTE <add more IM services here>
@@ -28,7 +28,7 @@ def sendIM(body: str, forceSend: bool = False) -> bool:
     return notification_result
 
 
-def sendTelegramMessage(body: str, apiKey: str, chatId: str) -> bool:
+def sendTelegramMessage(body: str, apiKey: str, chatId: str, disableNotifications: bool = True) -> bool:
     """Send a telegram message using rest api"""
     headers = {"Content-Type": "application/json"}
 
@@ -36,7 +36,7 @@ def sendTelegramMessage(body: str, apiKey: str, chatId: str) -> bool:
         "chat_id": chatId,
         "text": body,
         "parse_mode": "HTML",
-        "disable_notification": True,
+        "disable_notification": disableNotifications,
     }
     data = json.dumps(data_dict)
 


### PR DESCRIPTION
Hi, 

I have some teams that I still manually loot with so have come up with some changes to allow implementation of looting but still within the rules of the game, as it still requires manually sending to loot and completion of the captcha.

Essentially the implementation works like this:

1. Set team(s) tasks to "loot" as before
2. When looting teams are not in a loot, send a notification to the user on telegram that those crabs are sitting idle. They then have to manually go and send the crabs to loot and complete the captcha. I have set this telegram message to actually trigger a notification, as it is an active one and requires action, rather than other passive informative ones.
3. Sets an override time period (typically overnight, but can be whatever) where the teams that are set to loot will just go and mine. This is to not have them sitting idle all night whilst sleeping and for them to collect the looting points for the days looting.

Thanks,
Ali