### PR TITLE
Loot notification when teams idle

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Reinforce-specific features:
 
 - Run `python -m bin.looting.reinforceAttack <your address>` to reinforce all attacking teams with a crab from the tavern, using the reinforcement strategy specified in the .env file.
 - Run `python -m bin.looting.closeLoots <your address>` to settle and claim rewards on loots that can be settled.
+- Run `python -m bin.looting.notifyTeamsIdle <your address>` to notify when the looting teams are sitting idle and they are waiting to be manually sent to loot
 
 ### - What about attacking? 🤔
 

--- a/bin/looting/notifyTeamsIdle.py
+++ b/bin/looting/notifyTeamsIdle.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""
+Crabada script to notify user of idle looting teams
+for the given user address.
+
+Usage:
+    python3 -m bin.looting.notifyTeamsIdle <userAddress>
+
+Author:
+    @coccoinomane (Twitter)
+"""
+
+from src.bot.looting.notifyTeamsIdle import notifyTeamsIdle
+from src.helpers.general import secondOrNone
+from src.models.User import User
+from src.common.logger import logger
+from sys import argv
+
+userAddress = secondOrNone(argv)
+
+if not userAddress:
+    logger.error("Specify a user address")
+    exit(1)
+
+nClosed = notifyTeamsIdle(User(userAddress))

--- a/src/bot/looting/notifyTeamsIdle.py
+++ b/src/bot/looting/notifyTeamsIdle.py
@@ -1,7 +1,3 @@
-"""
-Notify a user where they have available looting teams sitting idle
-"""
-
 from src.common.logger import logger
 from src.helpers.instantMessage import sendIM
 from src.helpers.teams import fetchAvailableTeamsForTask

--- a/src/bot/looting/notifyTeamsIdle.py
+++ b/src/bot/looting/notifyTeamsIdle.py
@@ -22,6 +22,6 @@ def notifyTeamsIdle(user: User) -> int:
     # Notify user
     msg = f"You have teams sitting idle, go loot 🦀 [ids={', '.join(ids)}]"
     logger.info(msg)
-    sendIM(msg, silent=False)
+    sendIM(msg, forceSend=True, silent=False)
 
     return len(ids)

--- a/src/bot/looting/notifyTeamsIdle.py
+++ b/src/bot/looting/notifyTeamsIdle.py
@@ -3,41 +3,25 @@ Notify a user where they have available looting teams sitting idle
 """
 
 from src.common.logger import logger
-from src.common.txLogger import txLogger, logTx
 from src.helpers.instantMessage import sendIM
-from src.common.clients import makeCrabadaWeb3Client
 from src.helpers.teams import fetchAvailableTeamsForTask
 from src.models.User import User
-from web3.exceptions import ContractLogicError
 
 
 def notifyTeamsIdle(user: User) -> int:
     """
-    Send a notification to the user when they have available teams with the 'loot' task sitting idle
-    Notify the idle teams to the user
-
-    Returns the number of idle teams
+    Notify the user if he/she has teams with the 'loot'
+    task sitting idle; returns the number of idle teams.
     """
-    client = makeCrabadaWeb3Client(
-        upperLimitForBaseFeeInGwei=user.config["mineMaxGasInGwei"]
-    )
-    availableTeams = fetchAvailableTeamsForTask(user, "loot")
 
-    if not availableTeams:
-        logger.info("No available teams to send looting for user " + str(user.address))
+    # Get ids of idle teams
+    ids = [str(t["team_id"]) for t in fetchAvailableTeamsForTask(user, "loot")]
+    if not ids:
         return 0
 
-    # Loop through available looting teams
-    nIdleTeams = 0
-    for t in availableTeams:
+    # Notify user
+    msg = f"You have teams sitting idle, go loot 🦀 [ids={', '.join(ids)}]"
+    logger.info(msg)
+    sendIM(msg, silent=False)
 
-        # Send a notification of the idle team
-        teamId = t["team_id"]
-        logger.info(f"Team {teamId} is sitting idle! Go start the loot... 🦀")
-        sendIM(f"Team {teamId} is sitting idle! Go start the loot... 🦀", forceSend=True, disableNotifications=False);
-
-    return nIdleTeams
-
-
-Toucan
-Translate
+    return len(ids)

--- a/src/bot/looting/notifyTeamsIdle.py
+++ b/src/bot/looting/notifyTeamsIdle.py
@@ -1,5 +1,5 @@
 """
-Send a user's available teams mining
+Notify a user where they have available looting teams sitting idle
 """
 
 from src.common.logger import logger
@@ -13,10 +13,10 @@ from web3.exceptions import ContractLogicError
 
 def notifyTeamsIdle(user: User) -> int:
     """
-    Send mining the available teams with the 'mine' task
+    Send a notification to the user when they have available teams with the 'loot' task sitting idle
     Notify the idle teams to the user
 
-    Returns the opened mines
+    Returns the number of idle teams
     """
     client = makeCrabadaWeb3Client(
         upperLimitForBaseFeeInGwei=user.config["mineMaxGasInGwei"]
@@ -27,13 +27,17 @@ def notifyTeamsIdle(user: User) -> int:
         logger.info("No available teams to send looting for user " + str(user.address))
         return 0
 
-    # Send the teams
+    # Loop through available looting teams
     nIdleTeams = 0
     for t in availableTeams:
 
-        # Send team
+        # Send a notification of the idle team
         teamId = t["team_id"]
         logger.info(f"Team {teamId} is sitting idle! Go start the loot... 🦀")
         sendIM(f"Team {teamId} is sitting idle! Go start the loot... 🦀", forceSend=True, disableNotifications=False);
 
     return nIdleTeams
+
+
+Toucan
+Translate

--- a/src/bot/looting/notifyTeamsIdle.py
+++ b/src/bot/looting/notifyTeamsIdle.py
@@ -1,0 +1,39 @@
+"""
+Send a user's available teams mining
+"""
+
+from src.common.logger import logger
+from src.common.txLogger import txLogger, logTx
+from src.helpers.instantMessage import sendIM
+from src.common.clients import makeCrabadaWeb3Client
+from src.helpers.teams import fetchAvailableTeamsForTask
+from src.models.User import User
+from web3.exceptions import ContractLogicError
+
+
+def notifyTeamsIdle(user: User) -> int:
+    """
+    Send mining the available teams with the 'mine' task
+    Notify the idle teams to the user
+
+    Returns the opened mines
+    """
+    client = makeCrabadaWeb3Client(
+        upperLimitForBaseFeeInGwei=user.config["mineMaxGasInGwei"]
+    )
+    availableTeams = fetchAvailableTeamsForTask(user, "loot")
+
+    if not availableTeams:
+        logger.info("No available teams to send looting for user " + str(user.address))
+        return 0
+
+    # Send the teams
+    nIdleTeams = 0
+    for t in availableTeams:
+
+        # Send team
+        teamId = t["team_id"]
+        logger.info(f"Team {teamId} is sitting idle! Go start the loot... 🦀")
+        sendIM(f"Team {teamId} is sitting idle! Go start the loot... 🦀", forceSend=True, disableNotifications=False);
+
+    return nIdleTeams

--- a/src/helpers/instantMessage.py
+++ b/src/helpers/instantMessage.py
@@ -5,7 +5,7 @@ import requests
 import json
 
 
-def sendIM(body: str, forceSend: bool = False) -> bool:
+def sendIM(body: str, forceSend: bool = False, disableNotifications: bool = True) -> bool:
     """Send an notification message to the service configured in .env; won't send
     anything if notifications are disabled, unless forceSend is True"""
 
@@ -16,7 +16,7 @@ def sendIM(body: str, forceSend: bool = False) -> bool:
     try:
         if telegram["enable"]:
             notification_result = sendTelegramMessage(
-                body=body, apiKey=telegram["apiKey"], chatId=telegram["chatId"]
+                body=body, apiKey=telegram["apiKey"], chatId=telegram["chatId"], disableNotifications=disableNotifications
             )
 
         # NOTE <add more IM services here>
@@ -28,7 +28,7 @@ def sendIM(body: str, forceSend: bool = False) -> bool:
     return notification_result
 
 
-def sendTelegramMessage(body: str, apiKey: str, chatId: str) -> bool:
+def sendTelegramMessage(body: str, apiKey: str, chatId: str, disableNotifications: bool = True) -> bool:
     """Send a telegram message using rest api"""
     headers = {"Content-Type": "application/json"}
 
@@ -36,7 +36,7 @@ def sendTelegramMessage(body: str, apiKey: str, chatId: str) -> bool:
         "chat_id": chatId,
         "text": body,
         "parse_mode": "HTML",
-        "disable_notification": True,
+        "disable_notification": disableNotifications,
     }
     data = json.dumps(data_dict)
 

--- a/src/helpers/instantMessage.py
+++ b/src/helpers/instantMessage.py
@@ -4,7 +4,7 @@ import requests
 import json
 
 
-def sendIM(body: str, forceSend: bool = False, silent: bool = False) -> bool:
+def sendIM(body: str, forceSend: bool = False, silent: bool = True) -> bool:
     """
     Send an instant message to the services configured in .env;
     so far only Telegram is supported.

--- a/src/helpers/instantMessage.py
+++ b/src/helpers/instantMessage.py
@@ -1,24 +1,40 @@
 from src.common.config import notifications, telegram
 from src.common.logger import logger
-
 import requests
 import json
 
 
-def sendIM(body: str, forceSend: bool = False, disableNotifications: bool = True) -> bool:
-    """Send an notification message to the service configured in .env; won't send
-    anything if notifications are disabled, unless forceSend is True"""
+def sendIM(body: str, forceSend: bool = False, silent: bool = False) -> bool:
+    """
+    Send an instant message to the services configured in .env;
+    so far only Telegram is supported.
+
+    Parameters
+    ----------
+    body : str
+        The message to send; if the IM protocol supports it (Telegram does)
+        it can include emojis.
+    forceSend : bool
+        Send the notification even if notifications are disabled
+        at the config level.
+    silent : bool
+        Send a silent notification, if the IM protocol supports it
+        (Telegram does)
+    """
 
     if not notifications["instantMessage"]["enable"] and not forceSend:
         return True
 
     notification_result = False
+
     try:
         if telegram["enable"]:
             notification_result = sendTelegramMessage(
-                body=body, apiKey=telegram["apiKey"], chatId=telegram["chatId"], disableNotifications=disableNotifications
+                body=body,
+                apiKey=telegram["apiKey"],
+                chatId=telegram["chatId"],
+                disableNotifications=silent,
             )
-
         # NOTE <add more IM services here>
 
     except:
@@ -28,8 +44,14 @@ def sendIM(body: str, forceSend: bool = False, disableNotifications: bool = True
     return notification_result
 
 
-def sendTelegramMessage(body: str, apiKey: str, chatId: str, disableNotifications: bool = True) -> bool:
-    """Send a telegram message using rest api"""
+def sendTelegramMessage(
+    body: str, apiKey: str, chatId: str, disableNotifications: bool = True
+) -> bool:
+    """
+    Send a Telegram message using the REST api.
+
+    Docs: https://core.telegram.org/bots/api#sendmessage
+    """
     headers = {"Content-Type": "application/json"}
 
     data_dict = {

--- a/src/tests/testSendIM.py
+++ b/src/tests/testSendIM.py
@@ -1,15 +1,19 @@
+from sys import argv
 from src.helpers.instantMessage import sendIM
+from src.helpers.general import secondOrNone
 from pprint import pprint
 
 # VARS
+silent = False if secondOrNone(argv) == "1" else True
 body = "Join Earth's mightiest heroes. Like Kevin Bacon."
 
 # TEST FUNCTIONS
 def test() -> None:
     output = sendIM(
-        body=body,
-        forceSend=True,  # send IM regardless of settings
+        body=body, forceSend=True, silent=silent  # send IM regardless of settings
     )
+    print(">>> SILENT?")
+    pprint(silent)
     print(">>> SUCCESS?")
     pprint(output)
 


### PR DESCRIPTION
Hi,

A looting notification implementation. It works like this:

1. Set team(s) tasks to "loot" as before
2. When looting teams are not in a loot, send a notification to the user on telegram that those crabs are sitting idle. They then have to manually go and send the crabs to loot and complete the captcha. I have set this telegram message to actually trigger a notification, as it is an active one and requires action, rather than other passive informative ones.

As requested here:
https://github.com/coccoinomane/crabada.py/pull/73

Thanks,
Ali