### PR TITLE
WIP: Staggering teams

### DIFF
--- a/src/common/config.py
+++ b/src/common/config.py
@@ -38,6 +38,7 @@ if not users:
 
 nodeUri = getenv("WEB3_NODE_URI")
 reinforceDelayInSeconds = parseInt("REINFORCE_DELAY_IN_SECONDS", 30)
+staggeringDelayInMinutes = parseInt("STAGGERING_DELAY_IN_MINUTES", 35)
 donatePercentage = parsePercentage("DONATE_PERCENTAGE", 0)
 donateFrequency = parseInt("DONATE_FREQUENCY", 10)
 

--- a/src/helpers/config.py
+++ b/src/helpers/config.py
@@ -36,6 +36,7 @@ def parseTeamConfig(teamNumber: int, userNumber: int) -> ConfigTeam:
             f"{teamPrefix}_REINFORCE_STRATEGY", ["HighestBp"]
         ),
         "reinforcementToPick": parseInt(f"{teamPrefix}_REINFORCEMENT_TO_PICK", 1),
+        "staggeringPrevTeamId": parseInt(f"{teamPrefix}_STAGGERING_PREV_TEAM_ID", -1),
     }
 
     validateTeamConfig(teamConfig, teamNumber, userNumber)

--- a/src/helpers/teams.py
+++ b/src/helpers/teams.py
@@ -1,8 +1,49 @@
-from typing import List
-from src.common.types import TeamTask
+from typing import List, Dict
+from src.common.types import TeamTask, ConfigTeam
 from src.libs.CrabadaWeb2Client.types import Team
 from src.models.User import User
 from src.common.clients import makeCrabadaWeb2Client
+
+from datetime import datetime
+
+
+def _minutesElapsedSinceMiningStart(team: Team):
+    """returns time since given teams last mining"""
+    try:
+        timedelta = datetime.utcnow() - datetime.utcfromtimestamp(
+            team["mine_start_time"]
+        )
+        return int(timedelta.total_seconds() // 60)
+    except:
+        return 0
+
+
+def _fetchTeamsWithElapsedTime(user: User) -> Dict[int, int]:
+    # Fetch list of teams
+    allTeams = makeCrabadaWeb2Client().listTeams(
+        user.address, {"limit": 100, "page": 1}
+    )
+
+    result = {
+        team["team_id"]: _minutesElapsedSinceMiningStart(team) for team in allTeams
+    }
+    return result
+
+
+def _filterAvailableTeamsForStaggering(
+    teams: List[Team],
+    configTeams: Dict[int, ConfigTeam],
+    teamsWithMineTimings: Dict[int, int],
+):
+    available_teams: List[Team] = []
+    for t in teams:
+        team_id = t["team_id"]
+        prev_team_id = configTeams[team_id]["staggeringPrevTeamId"]
+        if prev_team_id == -1:
+            available_teams.append(t)
+        elif teamsWithMineTimings.get(prev_team_id, 0) > 30:
+            available_teams.append(t)
+    return available_teams
 
 
 def fetchAvailableTeamsForTask(user: User, task: TeamTask) -> List[Team]:
@@ -12,15 +53,23 @@ def fetchAvailableTeamsForTask(user: User, task: TeamTask) -> List[Team]:
     """
 
     # Teams that are supposed to perform the given task
-    ids = [t["id"] for t in user.getTeamsByTask(task)]
-
-    if not ids:
+    configTeams = {t["id"]: t for t in user.getTeamsByTask(task)}
+    if not configTeams:
         return []
 
     # Fetch list of available teams
     availableTeams = makeCrabadaWeb2Client().listTeams(
-        user.address, {"is_team_available": 1, "limit": len(ids) * 2, "page": 1}
+        user.address, {"is_team_available": 1, "limit": len(configTeams) * 2, "page": 1}
     )
 
     # Intersect teams with the task with available teams
-    return [t for t in availableTeams if t["team_id"] in ids]
+    availableTeams = [t for t in availableTeams if t["team_id"] in configTeams]
+
+    teamsWithMineTimings = _fetchTeamsWithElapsedTime(user=user)
+    availableTeams = _filterAvailableTeamsForStaggering(
+        teams=availableTeams,
+        configTeams=configTeams,
+        teamsWithMineTimings=teamsWithMineTimings,
+    )
+
+    return availableTeams

--- a/src/helpers/teams.py
+++ b/src/helpers/teams.py
@@ -3,6 +3,7 @@ from src.common.types import TeamTask, ConfigTeam
 from src.libs.CrabadaWeb2Client.types import Team
 from src.models.User import User
 from src.common.clients import makeCrabadaWeb2Client
+from src.common.config import staggeringDelayInMinutes
 
 from datetime import datetime
 
@@ -41,7 +42,7 @@ def _filterAvailableTeamsForStaggering(
         prev_team_id = configTeams[team_id]["staggeringPrevTeamId"]
         if prev_team_id == -1:
             available_teams.append(t)
-        elif teamsWithMineTimings.get(prev_team_id, 0) > 30:
+        elif teamsWithMineTimings.get(prev_team_id, 0) > staggeringDelayInMinutes:
             available_teams.append(t)
     return available_teams
 


### PR DESCRIPTION
Teams now have option to wait until XX minutes have passed since the previous team went mining.

**This probably will conflict with team-grouping functionality, but still could help you a bit.**

* New config: `USER_1_TEAM_1_STAGGERING_PREV_TEAM_ID` (default: -1)
* New config: `STAGGERING_DELAY_IN_MINUTES` (default: 35)
* `fetchAvailableTeamsForTask` function has an additional check.