### PR TITLE
Notification types toggles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,10 @@ USER_1_TEAM_1_REINFORCEMENT_TO_PICK="1" # increase to avoid reverted txs at a po
 # = NOTIFICATIONS =
 # =================
 NOTIFICATION_IM="0" # set to "1" to enable IM notifications
+NOTIFICATION_SEND="1"
+NOTIFICATION_REINFORCE="1"
+NOTIFICATION_CLOSE="1"
+NOTIFICATION_NOTIFY_IDLE="1"
 TELEGRAM_ENABLE="0" # set to "1" to enable telegram notifications
 TELEGRAM_API_KEY="123456789:AABBCCDDEE" # your api token (see https://core.telegram.org/bots#6-botfather) 
 TELEGRAM_CHAT_ID="123456" # your telegram user id

--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ Then, set your .env file:
 
 If everything worked fine, you should receive a Telegram message on your newly created bot.
 
+Note : Individual types of notifications can be toggled on or off by setting the following to on ("1") or off ("0"):
+NOTIFICATION_SEND, NOTIFICATION_REINFORCE, NOTIFICATION_CLOSE and NOTIFICATION_NOTIFY_IDLE.
+
+
 
 # To do
 

--- a/src/bot/looting/closeLoots.py
+++ b/src/bot/looting/closeLoots.py
@@ -53,6 +53,6 @@ def closeLoots(user: User) -> int:
             logger.info(f"Loot {gameId} closed correctly")
             if (notifications["instantMessage"]["onClose"]):
                 sendIM(f"Loot {gameId} closed correctly")
-                maybeDonate(txReceipt)
+            maybeDonate(txReceipt)
 
     return nClosedLoots

--- a/src/bot/looting/closeLoots.py
+++ b/src/bot/looting/closeLoots.py
@@ -1,7 +1,7 @@
 """
 Settle all loots of a given user
 """
-
+from src.common.config import notifications
 from src.common.logger import logger
 from src.common.txLogger import txLogger, logTx
 from src.helpers.instantMessage import sendIM
@@ -51,7 +51,8 @@ def closeLoots(user: User) -> int:
         else:
             nClosedLoots += 1
             logger.info(f"Loot {gameId} closed correctly")
-            sendIM(f"Loot {gameId} closed correctly")
-            maybeDonate(txReceipt)
+            if (notifications["instantMessage"]["onClose"]):
+                sendIM(f"Loot {gameId} closed correctly")
+                maybeDonate(txReceipt)
 
     return nClosedLoots

--- a/src/bot/looting/notifyTeamsIdle.py
+++ b/src/bot/looting/notifyTeamsIdle.py
@@ -1,0 +1,40 @@
+"""
+Notify a user where they have available looting teams sitting idle
+"""
+from src.common.config import notifications
+from src.common.logger import logger
+from src.common.txLogger import txLogger, logTx
+from src.helpers.instantMessage import sendIM
+from src.common.clients import makeCrabadaWeb3Client
+from src.helpers.teams import fetchAvailableTeamsForTask
+from src.models.User import User
+from web3.exceptions import ContractLogicError
+
+
+def notifyTeamsIdle(user: User) -> int:
+    """
+    Send a notification to the user when they have available teams with the 'loot' task sitting idle
+    Notify the idle teams to the user
+
+    Returns the number of idle teams
+    """
+    client = makeCrabadaWeb3Client(
+        upperLimitForBaseFeeInGwei=user.config["mineMaxGasInGwei"]
+    )
+    availableTeams = fetchAvailableTeamsForTask(user, "loot")
+
+    if not availableTeams:
+        logger.info("No available teams to send looting for user " + str(user.address))
+        return 0
+
+    # Loop through available looting teams
+    nIdleTeams = 0
+    for t in availableTeams:
+
+        # Send a notification of the idle team
+        teamId = t["team_id"]
+        logger.info(f"Team {teamId} is sitting idle! Go start the loot... 🦀")
+        if (notifications["instantMessage"]["onNotifyIdle"]):
+            sendIM(f"Team {teamId} is sitting idle! Go start the loot... 🦀", forceSend=True, disableNotifications=False);
+
+    return nIdleTeams

--- a/src/bot/looting/reinforceAttack.py
+++ b/src/bot/looting/reinforceAttack.py
@@ -1,7 +1,6 @@
 """
 Helper functions to reinforce all loots of a given user
 """
-
 from web3.main import Web3
 from src.common.exceptions import NoSuitableReinforcementFound
 from src.common.logger import logger
@@ -13,7 +12,7 @@ from src.common.clients import makeCrabadaWeb3Client
 from src.models.User import User
 from src.strategies.reinforce.ReinforceStrategyFactory import getBestReinforcement
 from time import sleep
-from src.common.config import reinforceDelayInSeconds
+from src.common.config import reinforceDelayInSeconds, notifications
 from web3.exceptions import ContractLogicError
 from src.libs.Web3Client.exceptions import TransactionTooExpensive
 
@@ -76,13 +75,13 @@ def reinforceAttack(user: User) -> int:
         logTx(txReceipt)
         if txReceipt["status"] != 1:
             logger.error(f"Error reinforcing loot {mineId}")
-            sendIM(crabInfoMsg)
-            sendIM(f"Error reinforcing loot {mineId}")
+            sendIM(f"Error reinforcing loot {mineId} : {crabInfoMsg}.")
         else:
             nBorrowedReinforments += 1
             logger.info(f"Loot {mineId} reinforced correctly")
-            sendIM(crabInfoMsg)
-            sendIM(f"Loot {mineId} reinforced correctly")
+            if (notifications["instantMessage"]["onReinforce"]):
+                sendIM(crabInfoMsg)
+                sendIM(f"Loot {mineId} reinforced correctly")
 
         # Wait some time to avoid renting the same crab for different teams
         if len(reinforceableMines) > 1:

--- a/src/bot/looting/reinforceAttack.py
+++ b/src/bot/looting/reinforceAttack.py
@@ -75,13 +75,12 @@ def reinforceAttack(user: User) -> int:
         logTx(txReceipt)
         if txReceipt["status"] != 1:
             logger.error(f"Error reinforcing loot {mineId}")
-            sendIM(f"Error reinforcing loot {mineId} : {crabInfoMsg}.")
+            sendIM(f"Error reinforcing loot {mineId}: {crabInfoMsg}.")
         else:
             nBorrowedReinforments += 1
             logger.info(f"Loot {mineId} reinforced correctly")
             if (notifications["instantMessage"]["onReinforce"]):
-                sendIM(crabInfoMsg)
-                sendIM(f"Loot {mineId} reinforced correctly")
+                sendIM(f"Loot {mineId} reinforced correctly. {crabInfoMsg.replace('Borrowing', 'Borrowed')}")
 
         # Wait some time to avoid renting the same crab for different teams
         if len(reinforceableMines) > 1:

--- a/src/bot/mining/closeMines.py
+++ b/src/bot/mining/closeMines.py
@@ -2,7 +2,7 @@
 Helper functions to close (i.e. claim rewards from) all mines
 of a given user
 """
-
+from src.common.config import notifications
 from src.common.logger import logger
 from src.common.txLogger import txLogger, logTx
 from src.helpers.instantMessage import sendIM
@@ -63,7 +63,8 @@ def closeMines(user: User) -> int:
         else:
             nClosedGames += 1
             logger.info(f"Mine {gameId} closed correctly")
-            sendIM(f"Mine {gameId} closed correctly")
+            if (notifications["instantMessage"]["onClose"]):
+                sendIM(f"Mine {gameId} closed correctly")
             maybeDonate(txReceipt)
 
     return nClosedGames

--- a/src/bot/mining/reinforceDefense.py
+++ b/src/bot/mining/reinforceDefense.py
@@ -13,7 +13,7 @@ from src.common.clients import makeCrabadaWeb3Client
 from src.models.User import User
 from src.strategies.reinforce.ReinforceStrategyFactory import getBestReinforcement
 from time import sleep
-from src.common.config import reinforceDelayInSeconds
+from src.common.config import reinforceDelayInSeconds, notifications
 from web3.exceptions import ContractLogicError
 from src.libs.Web3Client.exceptions import TransactionTooExpensive
 
@@ -76,14 +76,14 @@ def reinforceDefense(user: User) -> int:
         logTx(txReceipt)
         if txReceipt["status"] != 1:
             logger.error(f"Error reinforcing mine {mineId}")
-            sendIM(crabInfoMsg)
-            sendIM(f"Error reinforcing mine {mineId}")
+            sendIM(f"Error reinforcing mine {mineId} : {crabInfoMsg}.")
         else:
             nBorrowedReinforments += 1
             logger.info(f"Mine {mineId} reinforced correctly")
-            sendIM(crabInfoMsg)
-            sendIM(f"Mine {mineId} reinforced correctly")
-
+            if (notifications["instantMessage"]["onReinforce"]):
+                sendIM(crabInfoMsg)
+                sendIM(f"Loot {mineId} reinforced correctly")
+                
         # Wait some time to avoid renting the same crab for different teams
         if len(reinforceableMines) > 1:
             sleep(reinforceDelayInSeconds)

--- a/src/bot/mining/reinforceDefense.py
+++ b/src/bot/mining/reinforceDefense.py
@@ -76,13 +76,12 @@ def reinforceDefense(user: User) -> int:
         logTx(txReceipt)
         if txReceipt["status"] != 1:
             logger.error(f"Error reinforcing mine {mineId}")
-            sendIM(f"Error reinforcing mine {mineId} : {crabInfoMsg}.")
+            sendIM(f"Error reinforcing mine {mineId}: {crabInfoMsg}.")
         else:
             nBorrowedReinforments += 1
             logger.info(f"Mine {mineId} reinforced correctly")
             if (notifications["instantMessage"]["onReinforce"]):
-                sendIM(crabInfoMsg)
-                sendIM(f"Loot {mineId} reinforced correctly")
+                sendIM(f"Mine {mineId} reinforced correctly. {crabInfoMsg.replace('Borrowing', 'Borrowed')}")
                 
         # Wait some time to avoid renting the same crab for different teams
         if len(reinforceableMines) > 1:

--- a/src/bot/mining/sendTeamsMining.py
+++ b/src/bot/mining/sendTeamsMining.py
@@ -1,7 +1,7 @@
 """
 Send a user's available teams mining
 """
-
+from src.common.config import notifications
 from src.common.logger import logger
 from src.common.txLogger import txLogger, logTx
 from src.helpers.instantMessage import sendIM
@@ -50,6 +50,7 @@ def sendTeamsMining(user: User) -> int:
         else:
             nSentTeams += 1
             logger.info(f"Team {teamId} sent successfully")
-            sendIM(f"Team {teamId} sent successfully")
+            if (notifications["instantMessage"]["onSendingTeam"]):
+                sendIM(f"Team {teamId} sent successfully")
 
     return nSentTeams

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -54,5 +54,9 @@ telegram: Dict[str, Any] = {
 notifications: Dict[str, Any] = {
     "instantMessage": {
         "enable": parseBool("NOTIFICATION_IM", False),
+        "onSendingTeam": parseBool("NOTIFICATION_SEND", False),
+        "onReinforce": parseBool("NOTIFICATION_REINFORCE", False),
+        "onClose": parseBool("NOTIFICATION_CLOSE", False),
+        "onNotifyIdle": parseBool("NOTIFICATION_NOTIFY_IDLE", False),
     },
 }


### PR DESCRIPTION
Hi, 

This follows on from [PR](https://github.com/coccoinomane/crabada.py/pull/75). 

I've personally have found the number of notifications to be somewhat irritating (and my gf finds it irritating at night!!), so I've split out some configuration for some separate notification toggles. The reinforcement ones particularly so, as you tend to get a few in a row all at the same time and I just close them.

**Summary of changes**
1. Additional config in .env file so each type of notification can be toggled on or off separately (NOTIFICATION_SEND, NOTIFICATION_REINFORCE, NOTIFICATION_CLOSE and NOTIFICATION_NOTIFY_IDLE)
2. Added if statements to each of the /bot/mining and /bot/looting scripts for sendIM(x) to respect the config.
3. I have left all the errors on by default as these are obviously more important and may require action, but consolidated the error notification on the notify scripts in to one line as previously was sending two messages.
4. On reinforcement script, updated "Borrowing" to "Borrowed" after the fact.
5. Updated Readme with instructions

Thanks,
Ali