### PR TITLE
staggering-groups (simplistic approach for stagger config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ Desktop.ini
 .tox
 .cache
 .vscode/settings.json
+
+venv/

--- a/src/common/types.py
+++ b/src/common/types.py
@@ -1,4 +1,4 @@
-from typing import Literal, NewType, Tuple, TypedDict, List
+from typing import Literal, NewType, Tuple, TypedDict, List, Set
 from eth_typing import Address
 from web3.types import Wei
 
@@ -23,6 +23,10 @@ class ConfigTeam(TypedDict):
     groupNumber: int  # internal group number (0 if team not in a group)
 
 
+# Typing helper for staggering groups.
+StaggeringGroup = Set[int]
+
+
 class ConfigUser(TypedDict):
     address: Address
     privateKey: str
@@ -33,6 +37,8 @@ class ConfigUser(TypedDict):
     closeMineMaxGasInGwei: float
     closeLootMaxGasInGwei: float
     teams: List[ConfigTeam]
+    staggeringGroups: List[StaggeringGroup]
+    staggeringDelayInMinutes: int
 
 
 class ConfigContract(TypedDict):

--- a/src/helpers/config.py
+++ b/src/helpers/config.py
@@ -9,6 +9,7 @@ from web3 import Web3
 from src.common.exceptions import InvalidConfig, MissingConfig
 from src.common.types import (
     ConfigTeam,
+    StaggeringGroup,
     ConfigUser,
     Tus,
     TeamTask,
@@ -20,7 +21,7 @@ from src.common.dotenv import (
     parseListOfInts,
     parseListOfStrings,
 )
-from typing import List, cast
+from typing import List, cast, Set
 from eth_typing import Address
 
 from src.helpers.general import duplicatesInList, flattenList
@@ -104,13 +105,23 @@ def parseTeamConfig(
             f"{teamPrefix}_REINFORCE_STRATEGY", ["HighestBp"]
         ),
         "reinforcementToPick": parseInt(f"{teamPrefix}_REINFORCEMENT_TO_PICK", 1),
-        "teamNumber": teamNumber,
-        "groupNumber": groupNumber,
     }
 
     validateTeamConfig(teamConfig, teamNumber, userPrefix)
 
     return teamConfig
+
+
+def parseStaggeringGroups(userNumber: int) -> List[StaggeringGroup]:
+    staggeringGroups: List[StaggeringGroup] = []
+    groupNumber = 1
+    while getenv(f"USER_{userNumber}_STAGGER_GROUP_{groupNumber}_TEAMS"):
+        teamsIds = set(
+            parseListOfInts(f"USER_{userNumber}_STAGGER_GROUP_{groupNumber}_TEAMS")
+        )
+        staggeringGroups.append(teamsIds)
+        groupNumber += 1
+    return staggeringGroups
 
 
 def parseUserConfig(userNumber: int, teams: List[ConfigTeam]) -> ConfigUser:
@@ -145,6 +156,8 @@ def parseUserConfig(userNumber: int, teams: List[ConfigTeam]) -> ConfigUser:
             f"{userPrefix}_CLOSE_LOOT_MAX_GAS", float("inf")
         ),
         "teams": [t for t in teams if t["userAddress"] == address],
+        "staggeringGroups": parseStaggeringGroups(userNumber),
+        "staggeringDelayInMinutes": parseInt(f"{userPrefix}_STAGGER_DELAY", 35),
     }
 
     validateUserConfig(userConfig, userNumber)

--- a/src/helpers/staggering.py
+++ b/src/helpers/staggering.py
@@ -1,0 +1,127 @@
+from src.libs.CrabadaWeb2Client.types import Team
+from src.models.User import User
+from src.common.clients import makeCrabadaWeb2Client
+from src.common.types import StaggeringGroup, TeamTask, ConfigTeam
+from src.common.logger import logger
+
+from datetime import datetime
+from typing import List, Dict, Set
+
+
+def _minutesElapsedSinceMiningStart(team: Team):
+    """returns time elapsed since given teams last mining start date"""
+    try:
+        timedelta = datetime.utcnow() - datetime.utcfromtimestamp(
+            team["mine_start_time"]
+        )
+        return int(timedelta.total_seconds() // 60)
+    except:
+        return 0
+
+
+def _fetchTeamsWithElapsedTime(user: User) -> Dict[int, int]:
+    """returns a dictionary of team_ids and mining elapsed times.
+    fetches all teams of given user, and calculates the elapsed time from the last mining operation start date."""
+    try:
+        allTeams = makeCrabadaWeb2Client().listTeams(
+            user.address, {"limit": 100, "page": 1}
+        )
+
+        result = {
+            team["team_id"]: _minutesElapsedSinceMiningStart(team) for team in allTeams
+        }
+        return result
+    except:
+        return {}
+
+
+def _getMinimumElapsedTime(
+    staggeringGroup: StaggeringGroup,
+    allTeamsWithMineTimings: Dict[int, int],
+    exceptTeamId: int,
+):
+    """Finds minimum elapsed time since last mining expedition (for given staggering-group).
+    If there is no team currently mining returns a big-enough default value (currently 1000 minutes).
+    """
+    minimumElapsedTime = 10000  # TODO a bigint default value.
+    for team_id in staggeringGroup:
+        if team_id != exceptTeamId:
+            value = allTeamsWithMineTimings.get(team_id, minimumElapsedTime)
+            if value < minimumElapsedTime:
+                minimumElapsedTime = value
+    return minimumElapsedTime
+
+
+def _checkTeamForMineTimigs(
+    team: Team,
+    staggeringGroups: List[StaggeringGroup],
+    allTeamsWithMineTimings: Dict[int, int],
+    staggeringDelayinMinutes: int,
+) -> bool:
+    team_id = team["team_id"]
+    for staggeringGroup in staggeringGroups:
+
+        if team_id not in staggeringGroup:
+            continue
+
+        minimumElapsedTime = _getMinimumElapsedTime(
+            staggeringGroup, allTeamsWithMineTimings, team_id
+        )
+
+        if minimumElapsedTime < staggeringDelayinMinutes:
+            # Fail Fast :)
+            # We do not need to check other staggering-groups for this team.
+            return False
+
+    return True
+
+
+def _checkTeamForUniqueGroups(
+    team: Team, staggeringGroups: List[StaggeringGroup], filteredTeamIdSet: Set[int]
+) -> bool:
+
+    if not filteredTeamIdSet:
+        return True
+
+    team_id = team["team_id"]
+    for staggeringGroup in staggeringGroups:
+
+        if team_id not in staggeringGroup:
+            continue
+
+        res = any(t in filteredTeamIdSet for t in staggeringGroup)
+        if res:
+            return False
+    return True
+
+
+def filterAvailableTeamsForStaggering(user: User, teams: List[Team]) -> List[Team]:
+
+    staggeringGroups = user.getStaggeringGroups()
+    staggeringDelayinMinutes = user.getStaggeringDelayInMinutes()
+
+    # if there is no stagger-group definition found,
+    # return unmofidied list of teams.
+    if not staggeringGroups:
+        return teams
+
+    filteredTeams: List[Team] = []
+    filteredTeamIdSet: Set[int] = set()
+
+    # cache mine-timings of teams
+    allTeamsWithMineTimings = _fetchTeamsWithElapsedTime(user)
+
+    for team in teams:
+        if _checkTeamForMineTimigs(
+            team, staggeringGroups, allTeamsWithMineTimings, staggeringDelayinMinutes
+        ) and _checkTeamForUniqueGroups(team, staggeringGroups, filteredTeamIdSet):
+            filteredTeams.append(team)
+
+            # Should allow a single team per staggering-group
+            # keep team_id's in a set for faster finds.
+            filteredTeamIdSet.add(team["team_id"])
+        else:
+            logger.debug(
+                f"Team {team['team_id']} is filtered out by StaggeringGroups filter."
+            )
+    return filteredTeams

--- a/src/helpers/teams.py
+++ b/src/helpers/teams.py
@@ -4,6 +4,8 @@ from src.libs.CrabadaWeb2Client.types import Team
 from src.models.User import User
 from src.common.clients import makeCrabadaWeb2Client
 
+from .staggering import filterAvailableTeamsForStaggering
+
 
 def fetchAvailableTeamsForTask(user: User, task: TeamTask) -> List[Team]:
     """
@@ -23,4 +25,9 @@ def fetchAvailableTeamsForTask(user: User, task: TeamTask) -> List[Team]:
     )
 
     # Intersect teams with the task with available teams
-    return [t for t in availableTeams if t["team_id"] in ids]
+    availableTeams = [t for t in availableTeams if t["team_id"] in ids]
+
+    # Filter teams for staggering-agorithm.
+    availableTeams = filterAvailableTeamsForStaggering(user, availableTeams)
+
+    return availableTeams

--- a/src/models/User.py
+++ b/src/models/User.py
@@ -4,7 +4,7 @@ from eth_typing import Address
 from web3.types import Wei
 from src.common.config import users
 from src.common.exceptions import UserException
-from src.common.types import ConfigTeam, ConfigUser, Tus, TeamTask
+from src.common.types import ConfigTeam, ConfigUser, StaggeringGroup, Tus, TeamTask
 from src.helpers.general import findInListOfDicts, firstOrNone
 from src.libs.CrabadaWeb2Client.types import Game, TeamStatus
 from src.models.Model import Model
@@ -34,6 +34,12 @@ class User(Model):
         Return the user teams as specified in the configuration
         """
         return self.config["teams"]
+
+    def getStaggeringGroups(self) -> List[StaggeringGroup]:
+        return self.config["staggeringGroups"]
+
+    def getStaggeringDelayInMinutes(self) -> int:
+        return self.config["staggeringDelayInMinutes"]
 
     def getTeamConfigFromMine(self, mine: Game) -> Tuple[ConfigTeam, TeamStatus]:
         """


### PR DESCRIPTION
* More simplistic approach for staggering configurations: 

```
# You can group your staggering-teams in the following way (just like in Team grouping):
USER_1_STAGGER_GROUP_1_TEAMS=27001,27002,27003

# Multiple stagger-groups are possible. Just increment group number:
# USER_1_STAGGER_GROUP_1_TEAMS = ...
# USER_1_STAGGER_GROUP_2_TEAMS = ...
# ...

# optional. this defaults to 35 minutes anyway.
USER_1_STAGGER_DELAY=35
```

* Most of the work done in single file: `src/helpers/staggering.py`. @coccoinomane I think you can simply use this in your "mining strategies" implementation.

* Currently testing this with two wallets. One has 2 teams (staggering both of them), other one has 8 (6 of which uses staggering configuration).

## How does it work?

`filterAvailableTeamsForStaggering` checks for two things, 
1. for all teams defined in the same stagger-group, 35 minutes should have been passed since the last mining expedition start time.  
2. only single team at a time per stagger-group is allowed to start a mining expedition.
