### PR TITLE
Use file handlers with utf-8 encodings.

### DIFF
--- a/src/common/logger.py
+++ b/src/common/logger.py
@@ -23,7 +23,9 @@ os.makedirs(os.path.dirname(logFilepath), exist_ok=True)
 
 # Create handlers
 c_handler = logging.StreamHandler()
-f_handler = logging.handlers.TimedRotatingFileHandler(logFilepath, "midnight")
+f_handler = logging.handlers.TimedRotatingFileHandler(
+    logFilepath, "midnight", encoding="utf-8"
+)
 
 c_handler.setLevel(getenv("DEBUG_LEVEL", "WARNING"))
 f_handler.setLevel(getenv("DEBUG_LEVEL", "WARNING"))

--- a/src/helpers/donate.py
+++ b/src/helpers/donate.py
@@ -163,7 +163,7 @@ def logClaim(rewards: Tuple[float, float]) -> None:
     """
     Append a line to the claims file
     """
-    with open(getClaimsLogFilepath(), "a+") as file:
+    with open(getClaimsLogFilepath(), mode="a+", encoding="utf-8") as file:
         file.write("%10.5f %10.5f\n" % rewards)
 
 
@@ -172,7 +172,7 @@ def getClaimsFromLog() -> List[List[float]]:
     Fetch all the reward claims in the file log
     """
     try:
-        with open(getClaimsLogFilepath(), "r") as file:
+        with open(getClaimsLogFilepath(), mode="r", encoding="utf-8") as file:
             return [[float(x) for x in line.split()] for line in file]
     except FileNotFoundError:
         return []

--- a/src/libs/Web3Client/Web3Client.py
+++ b/src/libs/Web3Client/Web3Client.py
@@ -436,7 +436,7 @@ class Web3Client:
 
     @staticmethod
     def getContractAbiFromFile(fileName: str) -> Any:
-        with open(fileName) as file:
+        with open(fileName, encoding="utf-8") as file:
             return json.load(file)
 
     @staticmethod


### PR DESCRIPTION
I started with just fixing the logger, but I also decided to add it to all file read and write operations.

I don't know how it would behave if the current "claims.log" file is not utf-8. But this shouldn't be a problem as utf8 s usually more _comprehensive_ than system default encodings

FIXES #113